### PR TITLE
Include VS version in adfcproj props and targets file path

### DIFF
--- a/src/Adfc.VisualStudio.Extension.VS2017/Adfc.VisualStudio.Extension.VS2017.csproj
+++ b/src/Adfc.VisualStudio.Extension.VS2017/Adfc.VisualStudio.Extension.VS2017.csproj
@@ -240,7 +240,7 @@
     <VSIXSourceItem Include="ProjectSystem\Msbuild\**">
       <Visible>false</Visible>
       <InstallRoot>MSBuild</InstallRoot>
-      <VSIXSubPath>ADFCommunity\VS15\AdfcProj</VSIXSubPath>
+      <VSIXSubPath>ADFCommunity\VS15.0\AdfcProj</VSIXSubPath>
     </VSIXSourceItem>
   </ItemGroup>
   <ItemDefinitionGroup>

--- a/src/Adfc.VisualStudio.Template.Project/ProjectTemplate.adfcproj
+++ b/src/Adfc.VisualStudio.Template.Project/ProjectTemplate.adfcproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
   <PropertyGroup>
-    <AdfcProjectImportPath>$(MSBuildExtensionsPath)\ADFCommunity\VS15\AdfcProj\</AdfcProjectImportPath>
+    <AdfcProjectImportPath>$(MSBuildExtensionsPath)\ADFCommunity\VS$(VisualStudioVersion)\AdfcProj\</AdfcProjectImportPath>
   </PropertyGroup>
   <Import Project="$(AdfcProjectImportPath)\adfcproj.props" Condition="Exists('$(AdfcProjectImportPath)\adfcproj.props')"/>
   <ItemGroup>


### PR DESCRIPTION
Change the adfcproj template to include VS tooling files from path that includes VS version. This sets up future proofing for future versions of VS, and side-by-side installation.

Closes #22 